### PR TITLE
Create MothrClient class

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,16 @@ client connection when making multiple requests.
 from mothrpy import JobRequest, MothrClient
 
 client = MothrClient()
+
+# Send one request
 request = JobRequest(client=client, service='echo')
 request.add_parameter(value='Hello MOTHR!')
+result = request.run_job()
+print(result)
+
+# Reuse the client in another request
+request = JobRequest(client=client, service='echo')
+request.add_parameter(value='Hello again MOTHR!')
 result = request.run_job()
 print(result)
 ```

--- a/README.md
+++ b/README.md
@@ -12,10 +12,25 @@ dependencies
 
 ## Usage
 
+Basic example submitting a job request
+
 ```python
 from mothrpy import JobRequest
 
 request = JobRequest(service='echo')
+request.add_parameter(value='Hello MOTHR!')
+result = request.run_job()
+print(result)
+```
+
+Submitting a job request Using `MothrClient`. This allows you to reuse the
+client connection when making multiple requests.
+
+```python
+from mothrpy import JobRequest, MothrClient
+
+client = MothrClient()
+request = JobRequest(client=client, service='echo')
 request.add_parameter(value='Hello MOTHR!')
 result = request.run_job()
 print(result)

--- a/mothrpy/__init__.py
+++ b/mothrpy/__init__.py
@@ -2,4 +2,4 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-from .request import JobRequest
+from .request import JobRequest, MothrClient

--- a/mothrpy/request.py
+++ b/mothrpy/request.py
@@ -68,7 +68,7 @@ class MothrClient:
 
     def login(
         self, username: Optional[str] = None, password: Optional[str] = None
-    ) -> Tuple[str, Optional[str]]:
+    ) -> Tuple[str, str]:
         """Retrieve a web token from mothr
 
         Args:

--- a/mothrpy/request.py
+++ b/mothrpy/request.py
@@ -45,7 +45,7 @@ class MothrClient:
     def __init__(self, **kwargs):
         schemes = {"http": "ws", "https": "wss"}
         self.headers: Dict[str, str] = {}
-        endpoint = os.environ.get(URL_VAR, "http://localhost:8080/query")
+        endpoint = os.getenv(URL_VAR, "http://localhost:8080/query")
         url = kwargs.pop("url", endpoint)
         split_url = urlsplit(url)
         ws_url = urlunsplit(split_url._replace(scheme=schemes[split_url.scheme]))
@@ -86,12 +86,8 @@ class MothrClient:
             ValueError: If a username or password are not provided and are not found
                 in the current environment
         """
-        username = (
-            username if username is not None else os.environ.get("MOTHR_USERNAME")
-        )
-        password = (
-            password if password is not None else os.environ.get("MOTHR_PASSWORD")
-        )
+        username = username if username is not None else os.getenv("MOTHR_USERNAME")
+        password = password if password is not None else os.getenv("MOTHR_PASSWORD")
         if username is None:
             raise ValueError("Username not provided")
         if password is None:

--- a/mothrpy/request.py
+++ b/mothrpy/request.py
@@ -19,23 +19,10 @@ with open(
     schema = f.read()
 
 
-class JobRequest:
-    """Object used for submitting requests to mothr
-
-    Attributes:
-        job_id (str): Request job id returned from self.submit()
-        status (str): Status of the job
+class MothrClient:
+    """Client for connecting to MOTHR
 
     Args:
-        service (str): Service being invoked by the request
-        parameters (list<dict>, optional): Parameters to pass to the service
-        broadcast (list<str>, optional): PubSub channel to broadcast the job result to
-        inputs (list<str>, optional): A list of S3 URIs to be used as
-            inputs by the service
-        outputs (list<str>, optional): A list of S3 URIs to be uploaded by the service
-        input_stream (str, optional): Value to pass to service through stdin
-        output_metadata (dict): Metadata attached to job outputs
-        version (str, optional): Version of the service, default `latest`
         url (str, optional): Endpoint to send the job request,
             checks for ``MOTHR_ENDPOINT`` in environment variables otherwise
             defaults to ``http://localhost:8080/query``
@@ -64,20 +51,102 @@ class JobRequest:
         ws_transport = WebsocketsTransport(url=ws_url)
         self.ws_client = Client(transport=ws_transport, schema=schema)
 
-        token = kwargs.pop("token", os.environ.get("MOTHR_ACCESS_TOKEN"))
+        self.token = kwargs.pop("token", os.environ.get("MOTHR_ACCESS_TOKEN"))
         username = kwargs.pop("username", None)
         password = kwargs.pop("password", None)
         if username is None:
             username = os.environ.get("MOTHR_USERNAME")
         if password is None:
             password = os.environ.get("MOTHR_PASSWORD")
-        if token is not None:
-            self.headers = {"Authorization": f"Bearer {token}"}
+        if self.token is not None:
+            self.headers = {"Authorization": f"Bearer {self.token}"}
         elif None not in (username, password):
-            token, refresh = self.login(username, password)
-            os.environ["MOTHR_REFRESH_TOKEN"] = refresh
-            self.headers = {"Authorization": f"Bearer {token}"}
+            self.token, self.refresh = self.login(username, password)
+            self.headers = {"Authorization": f"Bearer {self.token}"}
 
+    def login(
+        self, username: Optional[str] = None, password: Optional[str] = None
+    ) -> Tuple[str, Optional[str]]:
+        """Retrieve a web token from mothr
+
+        Args:
+            username (str, optional): Username used to login, the library will look
+                for ``MOTHR_USERNAME`` in the environment as a fallback.
+            password (str, optional): Password used to login, the library will look
+                for ``MOTHR_PASSWORD`` in the environment as a fallback.
+
+        Returns:
+            str: An access token to pass with future requests
+            str: A refresh token for receiving a new access token
+                after the current token expires
+
+        Raises:
+            ValueError: If a username or password are not provided and are not found
+                in the current environment
+        """
+        username = (
+            username if username is not None else os.environ.get("MOTHR_USERNAME")
+        )
+        password = (
+            password if password is not None else os.environ.get("MOTHR_PASSWORD")
+        )
+        if username is None:
+            raise ValueError("Username not provided")
+        if password is None:
+            raise ValueError("Password not provided")
+
+        credentials = {"username": username, "password": password}
+        q = self.ds.Mutation.login.args(**credentials).select(
+            self.ds.LoginResponse.token, self.ds.LoginResponse.refresh
+        )
+        resp = self.ds.mutate(q)
+        tokens = resp["login"]
+        if tokens is None:
+            raise ValueError("Login failed")
+        access = tokens["token"]
+        refresh = tokens["refresh"]
+        return access, refresh
+
+    def refresh_token(self) -> str:
+        """Refresh an expired access token
+
+        Returns:
+            str: New access token
+        """
+        q = self.ds.Mutation.refresh.args(token=self.refresh).select(
+            self.ds.RefreshResponse.refresh
+        )
+        resp = self.ds.mutate(q)
+        if resp["refresh"] is None:
+            raise ValueError("Token refresh failed")
+        token = resp["refresh"]["token"]
+        self.token = token
+        self.headers["Authorization"] = f"Bearer {self.token}"
+        return token
+
+
+class JobRequest:
+    """Object used for submitting requests to mothr
+
+    Attributes:
+        job_id (str): Request job id returned from self.submit()
+        status (str): Status of the job
+
+    Args:
+        client (MOTHRClient): Client connection to MOTHR
+        service (str): Service being invoked by the request
+        parameters (list<dict>, optional): Parameters to pass to the service
+        broadcast (list<str>, optional): PubSub channel to broadcast the job result to
+        inputs (list<str>, optional): A list of S3 URIs to be used as
+            inputs by the service
+        outputs (list<str>, optional): A list of S3 URIs to be uploaded by the service
+        input_stream (str, optional): Value to pass to service through stdin
+        output_metadata (dict): Metadata attached to job outputs
+        version (str, optional): Version of the service, default `latest`
+    """
+
+    def __init__(self, **kwargs):
+        self.client = kwargs.pop("client", MothrClient())
         kwargs["parameters"] = kwargs.get("parameters", [])
         kwargs["outputMetadata"] = kwargs.get("output_metadata", {})
         self.req_args = kwargs
@@ -128,78 +197,6 @@ class JobRequest:
         self.req_args["outputMetadata"].update(metadata)
         return self
 
-    def login(
-        self, username: Optional[str] = None, password: Optional[str] = None
-    ) -> Tuple[str, Optional[str]]:
-        """Retrieve a web token from mothr
-
-        Args:
-            username (str, optional): Username used to login, the library will look
-                for ``MOTHR_USERNAME`` in the environment as a fallback.
-            password (str, optional): Password used to login, the library will look
-                for ``MOTHR_PASSWORD`` in the environment as a fallback.
-
-        Returns:
-            str: An access token to pass with future requests
-            str: A refresh token for receiving a new access token
-                after the current token expires
-
-        Raises:
-            ValueError: If a username or password are not provided and are not found
-                in the current environment
-        """
-        token = os.environ.get("MOTHR_ACCESS_TOKEN")
-        if token is not None:
-            return token, None
-
-        username = (
-            username if username is not None else os.environ.get("MOTHR_USERNAME")
-        )
-        password = (
-            password if password is not None else os.environ.get("MOTHR_PASSWORD")
-        )
-        if username is None:
-            raise ValueError("Username not provided")
-        if password is None:
-            raise ValueError("Password not provided")
-
-        credentials = {"username": username, "password": password}
-        q = self.ds.Mutation.login.args(**credentials).select(
-            self.ds.LoginResponse.token, self.ds.LoginResponse.refresh
-        )
-        resp = self.ds.mutate(q)
-        tokens = resp["login"]
-        if tokens is None:
-            raise ValueError("Login failed")
-        access = tokens["token"]
-        refresh = tokens["refresh"]
-        os.environ["MOTHR_ACCESS_TOKEN"] = access
-        os.environ["MOTHR_REFRESH_TOKEN"] = refresh
-        return access, refresh
-
-    def refresh_token(self) -> str:
-        """Refresh an expired access token
-
-        Returns:
-            str: New access token
-        """
-        current_token = self.headers["Authorization"].split(" ")[-1]
-        system_token = os.getenv("MOTHR_ACCESS_TOKEN", "")
-        if current_token != system_token:
-            token = system_token
-        else:
-            refresh = os.getenv("MOTHR_REFRESH_TOKEN")
-            q = self.ds.Mutation.refresh.args(token=refresh).select(
-                self.ds.RefreshResponse.refresh
-            )
-            resp = self.ds.mutate(q)
-            if resp["refresh"] is None:
-                raise ValueError("Token refresh failed")
-            token = resp["refresh"]["token"]
-            os.environ["MOTHR_ACCESS_TOKEN"] = token
-        self.headers["Authorization"] = f"Bearer {token}"
-        return token
-
     def submit(self) -> str:
         """Submit the job request
 
@@ -208,12 +205,12 @@ class JobRequest:
         """
         metadata = [{"key": k, "value": v} for k, v in self.req_args["outputMetadata"]]
         self.req_args["outputMetadata"] = metadata
-        q = self.ds.Mutation.submit_job.args(request=self.req_args).select(
-            self.ds.JobRequestResponse.job.select(
-                self.ds.Job.job_id, self.ds.Job.status
+        q = self.client.ds.Mutation.submit_job.args(request=self.req_args).select(
+            self.client.ds.JobRequestResponse.job.select(
+                self.client.ds.Job.job_id, self.client.ds.Job.status
             )
         )
-        resp = self.ds.mutate(q)
+        resp = self.client.ds.mutate(q)
         if "errors" in resp:
             raise ValueError("Error submitting job request: " + resp["errors"])
         job_id = resp["submitJob"]["job"]["jobId"]
@@ -236,9 +233,9 @@ class JobRequest:
         """
         if self.job_id is None:
             raise ValueError("Job ID is None, have you submitted the job?")
-        fields = [getattr(self.ds.Job, field) for field in fields]
-        q = self.ds.Query.job.args(jobId=self.job_id).select(*fields)
-        resp = self.ds.query(q)
+        fields = [getattr(self.client.ds.Job, field) for field in fields]
+        q = self.client.ds.Query.job.args(jobId=self.job_id).select(*fields)
+        resp = self.client.ds.query(q)
         return resp["job"]
 
     def check_status(self) -> str:
@@ -274,7 +271,7 @@ class JobRequest:
             }}
         """
         )
-        result = list(self.ws_client.subscribe(s))
+        result = list(self.client.ws_client.subscribe(s))
         return result[0]
 
     def subscribe_messages(self) -> Iterator[str]:
@@ -286,7 +283,7 @@ class JobRequest:
             }}
         """
         )
-        for result in self.ws_client.subscribe(s):
+        for result in self.client.ws_client.subscribe(s):
             yield result
 
     def run_job(

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setuptools.setup(
     description="Client library for interacting with MOTHR",
     packages=setuptools.find_packages(),
     include_package_data=True,
-    install_requires=["gql==3.0.0a1", "redis"],
+    install_requires=["gql==3.0.0a3", "redis"],
     extras_require={
         "dev": ["mock", "pytest", "pytest-cov", "pytest-mypy", "pytest-pylint"],
         "listener": ["gevent"],

--- a/test/test_listener.py
+++ b/test/test_listener.py
@@ -5,19 +5,45 @@ import sys
 
 from mothrpy.listener import Listener
 
+
 class TestListener:
-    @mock.patch('redis.StrictRedis')
+    @mock.patch("redis.StrictRedis")
     def setup_method(self, _, mock_redis):
         mock_redis.return_value.pubsub.return_value.listen.return_value = [
-            {'pattern': None, 'type': 'message', 'channel': 'test', 'data': 'test message'},        
-            {'pattern': 'test:*', 'type': 'pmessage', 'channel': 'test:testing', 'data': 'test message'},        
-            {'pattern': None, 'type': 'message', 'channel': 'test', 'data': 'test message2'},        
-            {'pattern': None, 'type': 'subscribe', 'channel': 'test', 'data': 'subscribe message'},        
-            {'pattern': None, 'type': 'message', 'channel': 'test', 'data': 'test message3'}        
+            {
+                "pattern": None,
+                "type": "message",
+                "channel": "test",
+                "data": "test message",
+            },
+            {
+                "pattern": "test:*",
+                "type": "pmessage",
+                "channel": "test:testing",
+                "data": "test message",
+            },
+            {
+                "pattern": None,
+                "type": "message",
+                "channel": "test",
+                "data": "test message2",
+            },
+            {
+                "pattern": None,
+                "type": "subscribe",
+                "channel": "test",
+                "data": "subscribe message",
+            },
+            {
+                "pattern": None,
+                "type": "message",
+                "channel": "test",
+                "data": "test message3",
+            },
         ]
-        self.listener = Listener(['test', 'test:*'])
+        self.listener = Listener(["test", "test:*"])
         self.listener.handle_message = mock.MagicMock()
 
     def test_run(self):
         self.listener.start()
-        assert(self.listener.handle_message.call_count == 4)
+        assert self.listener.handle_message.call_count == 4

--- a/test/test_request.py
+++ b/test/test_request.py
@@ -2,79 +2,83 @@ import mock
 import pytest
 from mothrpy import JobRequest, MothrClient
 
+
 class TestJobRequest:
     def setup_method(self, _):
-        self.submit_response = {'submitJob': {'job': {'jobId': 'test', 'status': 'submitted'}}}
+        self.submit_response = {
+            "submitJob": {"job": {"jobId": "test", "status": "submitted"}}
+        }
         self.query_response = [
-            {'job': {'status': 'submitted'}}, 
-            {'job': {'status': 'running'}}, 
-            {'job': {'status': 'complete'}}, 
-            {'job': {'status': 'complete'}}
+            {"job": {"status": "submitted"}},
+            {"job": {"status": "running"}},
+            {"job": {"status": "complete"}},
+            {"job": {"status": "complete"}},
         ]
 
-    @mock.patch('gql.dsl.DSLSchema.mutate')
-    @mock.patch('gql.dsl.DSLSchema.query')
+    @mock.patch("gql.dsl.DSLSchema.mutate")
+    @mock.patch("gql.dsl.DSLSchema.query")
     def test_run_job(self, mock_query, mock_mutate):
         mock_mutate.return_value = self.submit_response
         mock_query.side_effect = self.query_response
-        request = JobRequest(service='test')
+        request = JobRequest(service="test")
         result = request.run_job()
-        assert(result)
-        
-    @mock.patch('gql.dsl.DSLSchema.mutate')
-    @mock.patch('gql.dsl.DSLSchema.query')
+        assert result
+
+    @mock.patch("gql.dsl.DSLSchema.mutate")
+    @mock.patch("gql.dsl.DSLSchema.query")
     def test_run_job_fail(self, mock_query, mock_mutate):
         for i in [-1, -2]:
-            self.query_response[i]['job']['status'] = 'failed'
-            self.query_response[i]['job']['error'] = 'failed'
+            self.query_response[i]["job"]["status"] = "failed"
+            self.query_response[i]["job"]["error"] = "failed"
         mock_mutate.return_value = self.submit_response
         mock_query.side_effect = self.query_response
-        request = JobRequest(service='test')
+        request = JobRequest(service="test")
         with pytest.raises(RuntimeError):
             request.run_job()
-        
-    @mock.patch('gql.dsl.DSLSchema.mutate')
-    @mock.patch('gql.dsl.DSLSchema.query')
+
+    @mock.patch("gql.dsl.DSLSchema.mutate")
+    @mock.patch("gql.dsl.DSLSchema.query")
     def test_run_job_fail_return_failed(self, mock_query, mock_mutate):
         for i in [-1, -2]:
-            self.query_response[i]['job']['status'] = 'failed'
+            self.query_response[i]["job"]["status"] = "failed"
         mock_mutate.return_value = self.submit_response
         mock_query.side_effect = self.query_response
-        request = JobRequest(service='test')
+        request = JobRequest(service="test")
         result = request.run_job(return_failed=True)
-        assert(result['status'] == 'failed')
-        
-    @mock.patch('gql.Client.subscribe')
-    def test_subscribe(self, mock_subscribe):
-        mock_subscribe.return_value = ['test']
-        request = JobRequest(service='test')
-        result = request.subscribe()
-        assert(result == 'test')
-        
-    @mock.patch('gql.Client.subscribe')
-    def test_subscribe_messages(self, mock_subscribe):
-        mock_subscribe.return_value = [f'message {i+1}' for i in range(10)]
-        request = JobRequest(service='test')
-        messages = [m for m in request.subscribe_messages()]
-        assert(len(messages) == 10)
-        assert(messages[0] == 'message 1')
-        
-    def test_add_argument_chaining(self):
-        request = JobRequest(service='test')
-        request.add_input(value='foo') \
-               .add_output(value='bar') \
-               .add_parameter(value='baz') \
-               .add_output_metadata({'foo': 'bar'})
-        assert(len(request.req_args['parameters']) == 3)
-        assert(request.req_args['parameters'][0]['type'] == 'input')
-        assert(request.req_args['parameters'][1]['type'] == 'output')
-        assert(request.req_args['parameters'][2]['type'] == 'parameter')
-        assert(request.req_args['outputMetadata']['foo'] == 'bar')
+        assert result["status"] == "failed"
 
-    @mock.patch('gql.dsl.DSLSchema.mutate')
+    @mock.patch("gql.Client.subscribe")
+    def test_subscribe(self, mock_subscribe):
+        mock_subscribe.return_value = ["test"]
+        request = JobRequest(service="test")
+        result = request.subscribe()
+        assert result == "test"
+
+    @mock.patch("gql.Client.subscribe")
+    def test_subscribe_messages(self, mock_subscribe):
+        mock_subscribe.return_value = [f"message {i+1}" for i in range(10)]
+        request = JobRequest(service="test")
+        messages = [m for m in request.subscribe_messages()]
+        assert len(messages) == 10
+        assert messages[0] == "message 1"
+
+    def test_add_argument_chaining(self):
+        request = JobRequest(service="test")
+        request.add_input(value="foo").add_output(value="bar").add_parameter(
+            value="baz"
+        ).add_output_metadata({"foo": "bar"})
+        assert len(request.req_args["parameters"]) == 3
+        assert request.req_args["parameters"][0]["type"] == "input"
+        assert request.req_args["parameters"][1]["type"] == "output"
+        assert request.req_args["parameters"][2]["type"] == "parameter"
+        assert request.req_args["outputMetadata"]["foo"] == "bar"
+
+    @mock.patch("gql.dsl.DSLSchema.mutate")
     def test_login(self, mock_mutate):
-        mock_mutate.return_value = {'login':{'token':'access-token','refresh':'refresh-token'}}
+        mock_mutate.return_value = {
+            "login": {"token": "access-token", "refresh": "refresh-token"}
+        }
         client = MothrClient()
-        access, refresh =  client.login(username='test', password='password')
-        assert(access == 'access-token')
-        assert(refresh == 'refresh-token')
+        access, refresh = client.login(username="test", password="password")
+        assert access == "access-token"
+        assert refresh == "refresh-token"

--- a/test/test_request.py
+++ b/test/test_request.py
@@ -1,6 +1,6 @@
 import mock
 import pytest
-from mothrpy import JobRequest
+from mothrpy import JobRequest, MothrClient
 
 class TestJobRequest:
     def setup_method(self, _):
@@ -74,7 +74,7 @@ class TestJobRequest:
     @mock.patch('gql.dsl.DSLSchema.mutate')
     def test_login(self, mock_mutate):
         mock_mutate.return_value = {'login':{'token':'access-token','refresh':'refresh-token'}}
-        request = JobRequest(service='test')
-        access, refresh =  request.login(username='test', password='password')
+        client = MothrClient()
+        access, refresh =  client.login(username='test', password='password')
         assert(access == 'access-token')
         assert(refresh == 'refresh-token')


### PR DESCRIPTION
Using a client connection class will allow connections to MOTHR to be reused between job requests by passing the client in when the `JobRequest` is created. It will also allow for connection state like access and refresh tokens to be stored in the client so login isn't required for each `JobRequest` or through some global variables.